### PR TITLE
Add Zuul support to Spring Security Keycloak

### DIFF
--- a/test-eureka/src/main/resources/application.yml
+++ b/test-eureka/src/main/resources/application.yml
@@ -2,10 +2,13 @@
 eureka:
   instance:
     hostname: localhost
+    prefer-ip-address: true
+    ip-address: 127.0.0.1
   client:  # Not a client, don't register with yourself
     registerWithEureka: false
     fetchRegistry: false
   server:
     enable-self-preservation: false
 server:
+  address: localhost
   port: 1111   # HTTP (Tomcat) port

--- a/test-secured-service/src/main/java/com/test/secured/service/SecurityConfig.java
+++ b/test-secured-service/src/main/java/com/test/secured/service/SecurityConfig.java
@@ -13,6 +13,7 @@ import org.springframework.security.config.annotation.authentication.builders.Au
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.core.session.SessionRegistryImpl;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.authentication.session.RegisterSessionAuthenticationStrategy;
 import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy;
 
@@ -35,6 +36,11 @@ public class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter {
 	@Autowired
 	public void configureGlobal(AuthenticationManagerBuilder auth) throws Exception {
 		auth.authenticationProvider(keycloakAuthenticationProvider());
+	}
+
+	@Override
+	protected AuthenticationEntryPoint authenticationEntryPoint() {
+		return new ZuulAwareKeycloakAuthenticationEntryPoint();
 	}
 
 	@Bean

--- a/test-secured-service/src/main/java/com/test/secured/service/ZuulAwareFilter.java
+++ b/test-secured-service/src/main/java/com/test/secured/service/ZuulAwareFilter.java
@@ -1,0 +1,28 @@
+package com.test.secured.service;
+
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * HTTP servlet filter that wraps the current request in an {@link ZuulAwareRequestWrapper}
+ * to appropriately expose request parameters populated by Zuul.
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class ZuulAwareFilter extends OncePerRequestFilter implements Filter {
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+			throws ServletException, IOException {
+		chain.doFilter(new ZuulAwareRequestWrapper(request), response);
+	}
+}

--- a/test-secured-service/src/main/java/com/test/secured/service/ZuulAwareKeycloakAuthenticationEntryPoint.java
+++ b/test-secured-service/src/main/java/com/test/secured/service/ZuulAwareKeycloakAuthenticationEntryPoint.java
@@ -1,0 +1,28 @@
+package com.test.secured.service;
+
+import org.keycloak.adapters.springsecurity.authentication.KeycloakAuthenticationEntryPoint;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+import org.springframework.web.util.UriComponents;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * Zuul HTTP <code>x-forwarded-prefix</code> header aware authentication entry point.
+ */
+public class ZuulAwareKeycloakAuthenticationEntryPoint extends KeycloakAuthenticationEntryPoint {
+	private final Logger logger = LoggerFactory.getLogger(ZuulAwareKeycloakAuthenticationEntryPoint.class);
+
+	protected void commenceLoginRedirect(HttpServletRequest request, HttpServletResponse response) throws IOException {
+		String prefix = request.getHeader("x-forwarded-prefix");
+		UriComponents components =
+				ServletUriComponentsBuilder.fromRequest(request)
+						.replacePath((prefix != null ? prefix : "") + "/sso/login").build();
+
+		logger.info("Redirecting to login URI: {}", components.toUriString());
+		response.sendRedirect(components.toUriString());
+	}
+}

--- a/test-secured-service/src/main/java/com/test/secured/service/ZuulAwareRequestWrapper.java
+++ b/test-secured-service/src/main/java/com/test/secured/service/ZuulAwareRequestWrapper.java
@@ -1,0 +1,39 @@
+package com.test.secured.service;
+
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+import org.springframework.web.util.UriComponents;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+
+/**
+ * Provides an HTTP servlet request wrapper aware that this request may be
+ * proxied by Netflix Zuul.
+ */
+class ZuulAwareRequestWrapper extends HttpServletRequestWrapper {
+
+	private final HttpServletRequest request;
+
+	private final UriComponents components;
+
+	ZuulAwareRequestWrapper(HttpServletRequest request) {
+		super(request);
+		this.request = request;
+		this.components = ServletUriComponentsBuilder.fromRequest(request).build();
+	}
+
+	@Override
+	public String getRequestURI() {
+		return components.getPath();
+	}
+
+	@Override
+	public StringBuffer getRequestURL() {
+		return new StringBuffer(components.toUriString());
+	}
+
+	@Override
+	public int getServerPort() {
+		return components.getPort();
+	}
+}

--- a/test-secured-service/src/main/resources/application.yml
+++ b/test-secured-service/src/main/resources/application.yml
@@ -3,11 +3,16 @@ spring:
     name: SECURED-SERVICE
 server:
   port: 8083
+  address: 127.0.0.1
 eureka:
   instance:
     metadataMap:
       instanceId: ${spring.application.name}-${random.number}
+    ip-address: 127.0.0.1
+    hostname: localhost
+    prefer-ip-address: false
   client:
     enabled: true
     serviceUrl:
       defaultZone: http://${eureka.host:localhost}:${eureka.port:1111}/eureka/
+    use-dns-for-fetching-service-urls: false

--- a/test-zuul/src/main/resources/application.yml
+++ b/test-zuul/src/main/resources/application.yml
@@ -2,12 +2,19 @@ spring:
   application:
     name: ZUUL
 server:
+  address: 127.0.0.1
   port: 8765
 eureka:
   instance:
     metadataMap:
       instanceId: ${spring.application.name}-${random.number}
+    ip-address: 127.0.0.1
+    hostname: localhost
+    prefer-ip-address: false
   client:
     enabled: true
     serviceUrl:
       defaultZone: http://${eureka.host:localhost}:${eureka.port:1111}/eureka/
+    use-dns-for-fetching-service-urls: false
+zuul:
+  sensitive-headers: Authorization


### PR DESCRIPTION
These commits help Spring Security and Spring Security Keycloak be aware of the HTTP headers Zuul provides in order to construct login redirects properly.

Please do note that Zuul is intended to be a stateless proxy, so certain things like letting services set cookies isn't really ideal.

During testing, I noticed that Zuul provides the following HTTP headers to services:

```
accept-language
x-forwarded-host 
x-forwarded-proto
x-forwarded-prefix  <- interesting
x-forwarded-port
dnt
x-forwarded-for
accept-encoding
cache-control
user-agent
accept
netflix.nfhttpclient.version
x-netflix-httpclientname
host
connection
```

Of interest here is the not often used `x-forwarded-prefix`. This was important in establishing a correct redirect path.

The most problematic issue was that Zuul blocks cookies from being set and sent to clients. I'll note on the code which line allows this. Just keep in mind that [this is not recommended](http://cloud.spring.io/spring-cloud-netflix/spring-cloud-netflix.html)\* by Zuul's authors but is required for interactive authentication with Keycloak.

(*) See section on _Cookies and Sensitive Headers_
